### PR TITLE
feat: add csrf token generation and verification packages

### DIFF
--- a/pkg/csrf/errors.go
+++ b/pkg/csrf/errors.go
@@ -1,0 +1,10 @@
+package csrf
+
+import "errors"
+
+var (
+	ErrInvalidFormat    = errors.New("invalid CSRF token format")
+	ErrExpiredToken     = errors.New("CSRF token has expired")
+	ErrInvalidSignature = errors.New("CSRF token signature is invalid")
+	ErrInvalidTimestamp = errors.New("invalid timestamp in CSRF token")
+)

--- a/pkg/csrf/generate.go
+++ b/pkg/csrf/generate.go
@@ -1,0 +1,31 @@
+package csrf
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"time"
+)
+
+func GenerateToken(secret string) string {
+	timestamp := time.Now().Unix()
+	message := fmt.Sprintf("%d", timestamp)
+
+	h := hmac.New(sha256.New, []byte(secret))
+	h.Write([]byte(message))
+
+	signature := hex.EncodeToString(h.Sum(nil))
+	return fmt.Sprintf("%s:%s", message, signature)
+}
+
+func GenerateSecret() (string, error) {
+	secret := make([]byte, 32)
+	_, err := rand.Read(secret)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate CSRF token secret: %w", err)
+	}
+
+	return hex.EncodeToString(secret), nil
+}

--- a/pkg/csrf/generate.go
+++ b/pkg/csrf/generate.go
@@ -6,12 +6,13 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"strconv"
 	"time"
 )
 
 func GenerateToken(secret string) string {
 	timestamp := time.Now().Unix()
-	message := fmt.Sprintf("%d", timestamp)
+	message := strconv.FormatInt(timestamp, 10)
 
 	h := hmac.New(sha256.New, []byte(secret))
 	h.Write([]byte(message))

--- a/pkg/csrf/generate_test.go
+++ b/pkg/csrf/generate_test.go
@@ -1,0 +1,57 @@
+package csrf
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+func TestGenerateToken(t *testing.T) {
+	secret := "test-secret"
+
+	t.Run("Given a valid secret, When GenerateToken is called, Then it should return a valid token", func(t *testing.T) {
+		// Given
+		// Secret is already defined
+
+		// When
+		token := GenerateToken(secret)
+
+		// Then
+		parts := strings.Split(token, ":")
+		if len(parts) != 2 {
+			t.Errorf("expected token to have 2 parts separated by ':', got %v", parts)
+		}
+
+		timestamp := parts[0]
+		signature := parts[1]
+
+		if timestamp == "" {
+			t.Errorf("expected timestamp to be non-empty, got empty string")
+		}
+
+		if signature == "" {
+			t.Errorf("expected signature to be non-empty, got empty string")
+		}
+	})
+}
+
+func TestGenerateSecret(t *testing.T) {
+	t.Run("When GenerateSecret is called, Then it should return a valid secret", func(t *testing.T) {
+		// When
+		secret, err := GenerateSecret()
+
+		// Then
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		decoded, err := hex.DecodeString(secret)
+		if err != nil {
+			t.Errorf("expected secret to be a valid hex string, got error: %v", err)
+		}
+
+		if len(decoded) != 32 {
+			t.Errorf("expected secret to be 32 bytes, got %d bytes", len(decoded))
+		}
+	})
+}

--- a/pkg/csrf/verify.go
+++ b/pkg/csrf/verify.go
@@ -1,0 +1,47 @@
+package csrf
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// VerifyCSRFToken verifies the provided CSRF token using the secret.
+// It checks the token's signature and ensures it is not expired.
+func VerifyCSRFToken(token, secret string, maxAge time.Duration) error {
+	parts := strings.Split(token, ":")
+	if len(parts) != 2 {
+		return errors.New("invalid CSRF token format")
+	}
+
+	timestampStr, signature := parts[0], parts[1]
+
+	// Parse the timestamp
+	timestamp, err := strconv.ParseInt(timestampStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid timestamp in CSRF token: %w", err)
+	}
+
+	// Check token expiration
+	if time.Since(time.Unix(timestamp, 0)) > maxAge {
+		return errors.New("CSRF token has expired")
+	}
+
+	// Recreate the HMAC signature
+	message := fmt.Sprintf("%d", timestamp)
+	h := hmac.New(sha256.New, []byte(secret))
+	h.Write([]byte(message))
+	expectedSignature := hex.EncodeToString(h.Sum(nil))
+
+	// Compare the provided signature with the expected signature
+	if !hmac.Equal([]byte(signature), []byte(expectedSignature)) {
+		return errors.New("CSRF token signature is invalid")
+	}
+
+	return nil
+}

--- a/pkg/csrf/verify_test.go
+++ b/pkg/csrf/verify_test.go
@@ -1,0 +1,86 @@
+package csrf
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestVerifyCSRFToken(t *testing.T) {
+	secret := "test-secret"
+	maxAge := time.Minute * 5
+
+	t.Run("Given a valid CSRF token, When it is verified, Then it should succeed", func(t *testing.T) {
+		// Given
+		token := GenerateToken(secret)
+
+		// When
+		err := VerifyCSRFToken(token, secret, maxAge)
+
+		// Then
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("Given an expired CSRF token, When it is verified, Then it should fail", func(t *testing.T) {
+		// Given
+		timestamp := time.Now().Add(-maxAge - time.Minute).Unix()
+		message := fmt.Sprintf("%d", timestamp)
+		h := hmac.New(sha256.New, []byte(secret))
+		h.Write([]byte(message))
+		signature := hex.EncodeToString(h.Sum(nil))
+		token := fmt.Sprintf("%s:%s", message, signature)
+
+		// When
+		err := VerifyCSRFToken(token, secret, maxAge)
+
+		// Then
+		if err == nil || err.Error() != "CSRF token has expired" {
+			t.Errorf("expected 'CSRF token has expired', got %v", err)
+		}
+	})
+
+	t.Run("Given a token with an invalid signature, When it is verified, Then it should fail", func(t *testing.T) {
+		// Given
+		token := GenerateToken(secret)
+		invalidToken := token[:len(token)-1] + "x" // Corrupt the token
+
+		// When
+		err := VerifyCSRFToken(invalidToken, secret, maxAge)
+
+		// Then
+		if err == nil || err.Error() != "CSRF token signature is invalid" {
+			t.Errorf("expected 'CSRF token signature is invalid', got %v", err)
+		}
+	})
+
+	t.Run("Given a token with an invalid format, When it is verified, Then it should fail", func(t *testing.T) {
+		// Given
+		token := "invalid-token-format"
+
+		// When
+		err := VerifyCSRFToken(token, secret, maxAge)
+
+		// Then
+		if err == nil || err.Error() != "invalid CSRF token format" {
+			t.Errorf("expected 'invalid CSRF token format', got %v", err)
+		}
+	})
+
+	t.Run("Given a token with an invalid timestamp, When it is verified, Then it should fail", func(t *testing.T) {
+		// Given
+		token := "invalid-timestamp:signature"
+
+		// When
+		err := VerifyCSRFToken(token, secret, maxAge)
+
+		// Then
+		if err == nil || err.Error() != "invalid timestamp in CSRF token: strconv.ParseInt: parsing \"invalid-timestamp\": invalid syntax" {
+			t.Errorf("expected 'invalid timestamp in CSRF token', got %v", err)
+		}
+	})
+}


### PR DESCRIPTION
This pull request introduces a new CSRF token generation and verification system, including utility functions and comprehensive tests. The key changes include the implementation of token generation, secret generation, token verification, and corresponding unit tests to ensure robust functionality.

### New CSRF Token System:

* [`pkg/csrf/generate.go`](diffhunk://#diff-cfeb1bd063fd3f7158203ead35dec589097cf5845c53a5faa1ff6706b877f52dR1-R31): Added a `GenerateToken` function to create CSRF tokens using HMAC with a timestamp and a `GenerateSecret` function to generate secure random secrets.
* [`pkg/csrf/verify.go`](diffhunk://#diff-74e4a2c2432a1a4f5c170d52b7b72749b1a75bfec058b7c3865548422bc6a19bR1-R47): Implemented a `VerifyCSRFToken` function to validate CSRF tokens by checking their format, expiration, and HMAC signature.

### Unit Tests:

* [`pkg/csrf/generate_test.go`](diffhunk://#diff-5fe78013f1b2ec0f1a46e6340d368aa45534504295d5f286a7ff62cce94c6c27R1-R57): Added tests for `GenerateToken` and `GenerateSecret` to validate token structure, secret generation, and error handling.
* [`pkg/csrf/verify_test.go`](diffhunk://#diff-e6bed51412bf86ca5466c0a123d31631a41fe9ef8cfb43f18cc9743f805ad885R1-R86): Added tests for `VerifyCSRFToken` to cover valid tokens, expired tokens, invalid signatures, incorrect formats, and invalid timestamps.